### PR TITLE
feat(mobile): Add an StaticImageSlider to support Trim Audio

### DIFF
--- a/lib/src/widgets/trim/static_image_slider.dart
+++ b/lib/src/widgets/trim/static_image_slider.dart
@@ -1,0 +1,81 @@
+import 'dart:typed_data';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:video_editor/src/controller.dart';
+import 'package:video_editor/src/utils/helpers.dart';
+import 'package:video_editor/src/widgets/image_viewer.dart';
+import 'package:image/image.dart' as dart_image;
+
+class StaticImageSlider extends StatefulWidget {
+  const StaticImageSlider({
+    super.key,
+    required this.controller,
+    required this.imagePath,
+    this.height = 60,
+  });
+
+  /// The [height] param specifies the height of the generated thumbnails
+  final double height;
+
+  /// The [imagePath] param specified the path of the image to be filled in repeatedly inside the timeline body
+  final String imagePath;
+
+  final VideoEditorController controller;
+
+  @override
+  State<StaticImageSlider> createState() => _StaticImageSliderState();
+}
+
+class _StaticImageSliderState extends State<StaticImageSlider> {
+  // The width, height of the image's original dimensions
+  int imageWidth = 0;
+  int imageHeight = 0;
+
+  final _spaceWidth = 4.0;
+
+  @override
+  void initState() {
+    super.initState();
+    getImageDimensions(widget.imagePath);
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+  }
+
+  Future<void> getImageDimensions(String imagePath) async {
+    final byteData = await rootBundle.load(imagePath);
+    final img = dart_image.decodeImage(byteData.buffer.asUint8List());
+    setState(() {
+      imageWidth = img?.width ?? widget.height.toInt();
+      imageHeight = img?.height ?? widget.height.toInt();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (imageWidth == 0 || imageHeight == 0) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    final screenWidth = MediaQuery.of(context).size.width;
+    final int imageCount = (screenWidth / imageWidth).floor();
+
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: Row(
+        children: List.generate(
+          imageCount,
+          (index) => Image(
+            image: AssetImage(widget.imagePath),
+            width: imageWidth.toDouble(),
+            height: imageHeight.toDouble(),
+          ),
+        ).fold<List<Widget>>(
+            [], (acc, img) => acc..addAll([img, SizedBox(width: _spaceWidth)])),
+      ),
+    );
+  }
+}

--- a/lib/src/widgets/trim/static_image_slider.dart
+++ b/lib/src/widgets/trim/static_image_slider.dart
@@ -13,10 +13,14 @@ class StaticImageSlider extends StatefulWidget {
     required this.controller,
     required this.imagePath,
     this.height = 60,
+    this.width = 60,
   });
 
-  /// The [height] param specifies the height of the generated thumbnails
+  /// The [width, height] param specifies the width,height of component if failed to load image
+  ///
+  /// Default to 60
   final double height;
+  final double width;
 
   /// The [imagePath] param specified the path of the image to be filled in repeatedly inside the timeline body
   final String imagePath;
@@ -49,7 +53,7 @@ class _StaticImageSliderState extends State<StaticImageSlider> {
     final byteData = await rootBundle.load(imagePath);
     final img = dart_image.decodeImage(byteData.buffer.asUint8List());
     setState(() {
-      imageWidth = img?.width ?? widget.height.toInt();
+      imageWidth = img?.width ?? widget.width.toInt();
       imageHeight = img?.height ?? widget.height.toInt();
     });
   }

--- a/lib/src/widgets/trim/static_image_slider.dart
+++ b/lib/src/widgets/trim/static_image_slider.dart
@@ -36,17 +36,10 @@ class _StaticImageSliderState extends State<StaticImageSlider> {
   int imageWidth = 0;
   int imageHeight = 0;
 
-  final _spaceWidth = 4.0;
-
   @override
   void initState() {
     super.initState();
     getImageDimensions(widget.imagePath);
-  }
-
-  @override
-  void dispose() {
-    super.dispose();
   }
 
   Future<void> getImageDimensions(String imagePath) async {
@@ -65,20 +58,19 @@ class _StaticImageSliderState extends State<StaticImageSlider> {
     }
 
     final screenWidth = MediaQuery.of(context).size.width;
-    final int imageCount = (screenWidth / imageWidth).floor();
-
     return SingleChildScrollView(
       scrollDirection: Axis.horizontal,
       child: Row(
-        children: List.generate(
-          imageCount,
-          (index) => Image(
-            image: AssetImage(widget.imagePath),
-            width: imageWidth.toDouble(),
-            height: imageHeight.toDouble(),
-          ),
-        ).fold<List<Widget>>(
-            [], (acc, img) => acc..addAll([img, SizedBox(width: _spaceWidth)])),
+        children: <Widget>[
+          Container(
+            child: Image.asset(
+              widget.imagePath,
+              width: screenWidth,
+              height: imageHeight.toDouble(),
+              repeat: ImageRepeat.repeatX,
+            ),
+          )
+        ],
       ),
     );
   }

--- a/lib/src/widgets/trim/static_image_slider.dart
+++ b/lib/src/widgets/trim/static_image_slider.dart
@@ -4,23 +4,19 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:video_editor/src/controller.dart';
 import 'package:video_editor/src/utils/helpers.dart';
-import 'package:video_editor/src/widgets/image_viewer.dart';
-import 'package:image/image.dart' as dart_image;
 
-class StaticImageSlider extends StatefulWidget {
+class StaticImageSlider extends StatelessWidget {
   const StaticImageSlider({
     super.key,
     required this.controller,
     required this.imagePath,
     this.height = 60,
-    this.width = 60,
   });
 
-  /// The [width, height] param specifies the width,height of component if failed to load image
+  /// The [height] param specifies the height of component
   ///
   /// Default to 60
   final double height;
-  final double width;
 
   /// The [imagePath] param specified the path of the image to be filled in repeatedly inside the timeline body
   final String imagePath;
@@ -28,35 +24,7 @@ class StaticImageSlider extends StatefulWidget {
   final VideoEditorController controller;
 
   @override
-  State<StaticImageSlider> createState() => _StaticImageSliderState();
-}
-
-class _StaticImageSliderState extends State<StaticImageSlider> {
-  // The width, height of the image's original dimensions
-  int imageWidth = 0;
-  int imageHeight = 0;
-
-  @override
-  void initState() {
-    super.initState();
-    getImageDimensions(widget.imagePath);
-  }
-
-  Future<void> getImageDimensions(String imagePath) async {
-    final byteData = await rootBundle.load(imagePath);
-    final img = dart_image.decodeImage(byteData.buffer.asUint8List());
-    setState(() {
-      imageWidth = img?.width ?? widget.width.toInt();
-      imageHeight = img?.height ?? widget.height.toInt();
-    });
-  }
-
-  @override
   Widget build(BuildContext context) {
-    if (imageWidth == 0 || imageHeight == 0) {
-      return const Center(child: CircularProgressIndicator());
-    }
-
     final screenWidth = MediaQuery.of(context).size.width;
     return SingleChildScrollView(
       scrollDirection: Axis.horizontal,
@@ -64,9 +32,9 @@ class _StaticImageSliderState extends State<StaticImageSlider> {
         children: <Widget>[
           Container(
             child: Image.asset(
-              widget.imagePath,
+              imagePath,
               width: screenWidth,
-              height: imageHeight.toDouble(),
+              height: height,
               repeat: ImageRepeat.repeatX,
             ),
           )

--- a/lib/src/widgets/trim/trim_slider.dart
+++ b/lib/src/widgets/trim/trim_slider.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:video_editor/src/controller.dart';
+import 'package:video_editor/src/widgets/trim/static_image_slider.dart';
 import 'package:video_editor/src/widgets/trim/thumbnail_slider.dart';
 import 'package:video_editor/src/widgets/trim/trim_slider_painter.dart';
 
@@ -22,7 +23,14 @@ class TrimSlider extends StatefulWidget {
     this.hasHaptic = true,
     this.maxViewportRatio = 2.5,
     this.scrollController,
+    this.staticImagePath = '',
   });
+
+  /// The [staticImagePath] param indicate that a static image is used to fill into the timeline body repeated instead of
+  /// the video thumbnails
+  ///
+  /// /// Defaults to ''
+  final String staticImagePath;
 
   /// The [controller] param is mandatory so every change in the controller settings will propagate in the trim slider view
   final VideoEditorController controller;
@@ -598,10 +606,16 @@ class _TrimSliderState extends State<TrimSlider>
                         child: SizedBox(
                           height: widget.height,
                           width: _fullLayout.width,
-                          child: ThumbnailSlider(
-                            controller: widget.controller,
-                            height: widget.height,
-                          ),
+                          child: widget.staticImagePath != ''
+                              ? StaticImageSlider(
+                                  controller: widget.controller,
+                                  height: widget.height,
+                                  imagePath: widget.staticImagePath,
+                                )
+                              : ThumbnailSlider(
+                                  controller: widget.controller,
+                                  height: widget.height,
+                                ),
                         ),
                       ),
                       if (widget.child != null)

--- a/lib/src/widgets/trim/trim_slider.dart
+++ b/lib/src/widgets/trim/trim_slider.dart
@@ -606,7 +606,7 @@ class _TrimSliderState extends State<TrimSlider>
                         child: SizedBox(
                           height: widget.height,
                           width: _fullLayout.width,
-                          child: widget.staticImagePath != ''
+                          child: widget.staticImagePath.isNotEmpty
                               ? StaticImageSlider(
                                   controller: widget.controller,
                                   width: _fullLayout.width,

--- a/lib/src/widgets/trim/trim_slider.dart
+++ b/lib/src/widgets/trim/trim_slider.dart
@@ -609,7 +609,6 @@ class _TrimSliderState extends State<TrimSlider>
                           child: widget.staticImagePath.isNotEmpty
                               ? StaticImageSlider(
                                   controller: widget.controller,
-                                  width: _fullLayout.width,
                                   height: widget.height,
                                   imagePath: widget.staticImagePath,
                                 )

--- a/lib/src/widgets/trim/trim_slider.dart
+++ b/lib/src/widgets/trim/trim_slider.dart
@@ -609,6 +609,7 @@ class _TrimSliderState extends State<TrimSlider>
                           child: widget.staticImagePath != ''
                               ? StaticImageSlider(
                                   controller: widget.controller,
+                                  width: _fullLayout.width,
                                   height: widget.height,
                                   imagePath: widget.staticImagePath,
                                 )


### PR DESCRIPTION
1. Create a new StaticImageSlider class and its StatefulWidget
2. Provide a file path and the widget can parse its dimensions as the default width/height
3. Build the layout to repeatedly display the image inside the trimmer timeiline

[TF3R-1444]

[TF3R-1444]: https://xrspace.atlassian.net/browse/TF3R-1444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ