### PR TITLE
fix(mobile): fix RangeError

### DIFF
--- a/lib/src/widgets/trim/thumbnail_slider.dart
+++ b/lib/src/widgets/trim/thumbnail_slider.dart
@@ -106,7 +106,7 @@ class _ThumbnailSliderState extends State<ThumbnailSlider> {
         stream: _stream,
         builder: (_, snapshot) {
           final data = snapshot.data;
-          return snapshot.hasData
+          return snapshot.hasData && data != null && data.isNotEmpty
               ? ListView.builder(
                   scrollDirection: Axis.horizontal,
                   padding: EdgeInsets.zero,


### PR DESCRIPTION
VideoEditor 內僅用 snapshot.hasData 不夠準確
進而導致後方會跳 exception: RangeError (length): Invalid value: Valid value range is empty: 0

Jira Issue: https://xrspace.atlassian.net/browse/TFANP-2070